### PR TITLE
Add overflow-x: auto to <pre>

### DIFF
--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -1,3 +1,7 @@
+pre {
+  overflow-x: auto;
+}
+
 code {
   display: inline-block;
   line-height: $line-height / 1.5;


### PR DESCRIPTION
Per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x#Values):
> `auto` Depends on the user agent. If content fits inside the padding box, it looks the same as `visible`, but still establishes a new block-formatting context. Desktop browsers provide scrollbars if content overflows.
